### PR TITLE
make mc::result variadic, hide tuple from users

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ void main() {
     .fail([](int error) -> mc::result<void> {  // Explicitly recover from the error
       return {};
     })
-    .then([] () -> mc::result<std::tuple<int, int>> {  // TODO: hide std::tuple; mc::result<T1, T2, ...>
+    .then([] () -> mc::result<int, int> {
       return sum1(1, 3) && sum2(1, 3);
     })
     .then([] (int s1, int s2) {

--- a/test/test_future.cpp
+++ b/test/test_future.cpp
@@ -591,7 +591,7 @@ TEST(future, can_return_composed_futures) {
   auto call_count = std::make_shared<int>();
 
   mc::make_successful_future<void>()
-    .then([] () -> mc::result<std::tuple<int, int>> {
+    .then([] () -> mc::result<int, int> {
       return mc::make_successful_future<int>(123) && mc::make_successful_future<int>(444);
     })
     .then([call_count] (int i1, int i2) {


### PR DESCRIPTION
`mc::result` is now variadic, `std::tuple` was hidden behind `mc::result` (it is possible to use `mc::result<int, int>` instead of `mc::result<std::tuple<int, int>>`)