### PR TITLE
Use parenthesis instead of curly bracket to initialize value in result

### DIFF
--- a/include/minicoros/future.h
+++ b/include/minicoros/future.h
@@ -379,7 +379,7 @@ public:
   result(future<type>&& coro) : value_(MINICOROS_STD::move(coro)) {}
 
   template<typename OtherType>
-  result(OtherType&& value) : value_(StoredType{MINICOROS_STD::move(value)}) {}
+  result(OtherType&& value) : value_(StoredType(MINICOROS_STD::move(value))) {}
 
   result(failure&& f) : value_(MINICOROS_STD::move(f)) {}
 


### PR DESCRIPTION
Helps avoid unintentional initializer list construction.

This could be a bug or a feature, but it created hard to reason about code flow for us.

Had a bug where bar's fail case would only initialize `data1`, and leave anything else default constructed, or uninitialized.
```
struct FooType
{
	std::optional<Data> data1;
	int data2;
};
mc::future<FooType> foo() { ... }

mc::future<FooType> bar()
{
    return foo()
		.fail([&](auto&& error) -> mc::result<FooType>
		{
			if (condition) {
				return eastl::nullopt;
			}

			return mc::failure(eastl::move(error));
		});
}
```